### PR TITLE
Essential PyFFI fixes for NIF import

### DIFF
--- a/pyffi/formats/nif/__init__.py
+++ b/pyffi/formats/nif/__init__.py
@@ -2406,24 +2406,24 @@ class NifFormat(FileFormat):
         def apply_scale(self, scale):
             """Scale data."""
             # apply scale on transform
-            self.sub_constraint.ragdoll.pivot_a.x *= scale
-            self.sub_constraint.ragdoll.pivot_a.y *= scale
-            self.sub_constraint.ragdoll.pivot_a.z *= scale
-            self.sub_constraint.ragdoll.pivot_b.x *= scale
-            self.sub_constraint.ragdoll.pivot_b.y *= scale
-            self.sub_constraint.ragdoll.pivot_b.z *= scale
-            self.sub_constraint.limited_hinge.pivot_a.x *= scale
-            self.sub_constraint.limited_hinge.pivot_a.y *= scale
-            self.sub_constraint.limited_hinge.pivot_a.z *= scale
-            self.sub_constraint.limited_hinge.pivot_b.x *= scale
-            self.sub_constraint.limited_hinge.pivot_b.y *= scale
-            self.sub_constraint.limited_hinge.pivot_b.z *= scale
+            self.ragdoll.pivot_a.x *= scale
+            self.ragdoll.pivot_a.y *= scale
+            self.ragdoll.pivot_a.z *= scale
+            self.ragdoll.pivot_b.x *= scale
+            self.ragdoll.pivot_b.y *= scale
+            self.ragdoll.pivot_b.z *= scale
+            self.limited_hinge.pivot_a.x *= scale
+            self.limited_hinge.pivot_a.y *= scale
+            self.limited_hinge.pivot_a.z *= scale
+            self.limited_hinge.pivot_b.x *= scale
+            self.limited_hinge.pivot_b.y *= scale
+            self.limited_hinge.pivot_b.z *= scale
 
         def update_a_b(self, parent):
             """Update the B data from the A data."""
             transform = self.get_transform_a_b(parent)
-            self.sub_constraint.limited_hinge.update_a_b(transform)
-            self.sub_constraint.ragdoll.update_a_b(transform)
+            self.limited_hinge.update_a_b(transform)
+            self.ragdoll.update_a_b(transform)
 
     class bhkMoppBvTreeShape:
         def get_mass_center_inertia(self, density=1, solid=True):

--- a/pyffi/formats/nif/__init__.py
+++ b/pyffi/formats/nif/__init__.py
@@ -2335,17 +2335,17 @@ class NifFormat(FileFormat):
         def apply_scale(self, scale):
             """Scale data."""
             # apply scale on transform
-            self.sub_constraint.limited_hinge.pivot_a.x *= scale
-            self.sub_constraint.limited_hinge.pivot_a.y *= scale
-            self.sub_constraint.limited_hinge.pivot_a.z *= scale
-            self.sub_constraint.limited_hinge.pivot_b.x *= scale
-            self.sub_constraint.limited_hinge.pivot_b.y *= scale
-            self.sub_constraint.limited_hinge.pivot_b.z *= scale
+            self.limited_hinge.pivot_a.x *= scale
+            self.limited_hinge.pivot_a.y *= scale
+            self.limited_hinge.pivot_a.z *= scale
+            self.limited_hinge.pivot_b.x *= scale
+            self.limited_hinge.pivot_b.y *= scale
+            self.limited_hinge.pivot_b.z *= scale
 
         def update_a_b(self, parent):
             """Update the B data from the A data. The parent argument is simply a
             common parent to the entities."""
-            self.sub_constraint.limited_hinge.update_a_b(self.get_transform_a_b(parent))
+            self.limited_hinge.update_a_b(self.get_transform_a_b(parent))
 
     class bhkListShape:
         def get_mass_center_inertia(self, density = 1, solid = True):


### PR DESCRIPTION
Fixes core issues with pyffi that bug the nif importer.

@niftools/pyffi-reviewer 

# Overview
- patches get_skin_deformation() to take care of previously broken skinning for Wildlife Park 2&3 - would scale mesh to zero. Could wrap the actual skinning in a helper function to re-use code and save some lines.
- corrects incorrect properties in bhkLimitedHingeConstraint & bhkMalleableConstraint that prevented import due to apply_scale

## Fixes Known Issues
-

## Documentation
-

## Testing
-

### Manual
- import into blender, apply skin deformation on WLP NIF
- import Skyrim dog skeleton, crash disappears

### Automated
- ?

## Additional Information
- equivalent code for get_skin_deformation() fix is implemented in my nif scripts fork but it should clearly go into pyffi

